### PR TITLE
Disable psy shell update check

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -41,7 +41,9 @@ class TinkerCommand extends Command
     {
         $this->getApplication()->setCatchExceptions(false);
 
-        $config = new Configuration;
+        $config = new Configuration([
+            'updateCheck' => 'never'
+        ]);
 
         $config->getPresenter()->addCasters(
             $this->getCasters()


### PR DESCRIPTION
Psy Shell will, [by default](http://psysh.org/#all-the-options), check for updates on a weekly basis by making a [file_get_contents request to github](https://github.com/bobthecow/psysh/blob/master/src/Psy/VersionUpdater/GitHubChecker.php#L73). The first successful response will be cached.

However, on machines that don't have the ability to make external calls to the internet ( like intranet sites or those on otherwise proxied networks ), this feature causes the shell to hang for ( about ) 60 seconds on launch before you can do anything. Plus, because the response fails and doesn't cache, it'll happen every time.

I feel like this is a feature that doesn't really add much value, so this pull request disables it outright.

If you prefer to leave it as an option however, I have created two variant branches:

https://github.com/jhoff/laravel-tinker/commit/1b6922acfe1ff52ec42a731a65f8133a6531cebf - Update check disabled by default, adds option to check at start
https://github.com/jhoff/laravel-tinker/commit/c8cdd29e6e9a73e57e4c2fa6490e738560aef594 - Update check enabled by default, adds option to skip the check

I'm happy to submit either of these as a separate pull request.

Another possibility could be to maybe make it not check if the application is in production?