### PR TITLE
Add symfony/var-dumper 2.7.* version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/contracts": "~5.1",
         "illuminate/support": "~5.1",
         "psy/psysh": "0.7.*|0.8.*",
-        "symfony/var-dumper": "~3.0"
+        "symfony/var-dumper": "~2.7|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0|~5.0"


### PR DESCRIPTION
Both Laravel and Lumen 5.1 require `symfony/var-dumper 2.7.*`, since this package is using illuminate 5.1 components, i figured it should be compatible with 5.1 as well.

Resolves: #16 