### PR TITLE
Fix "Failed opening required"

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -54,7 +54,7 @@ class TinkerCommand extends Command
         $shell->addCommands($this->getCommands());
         $shell->setIncludes($this->argument('include'));
 
-        $path = $this->getLaravel()->basePath('vendor/composer/autoload_classmap.php');
+        $path = $this->getLaravel()->basePath().'/vendor/composer/autoload_classmap.php';
 
         $loader = ClassAliasAutoloader::register($shell, $path);
 


### PR DESCRIPTION
Method "basePath" doesn't get any arguments and it tries to include base directory and we got the error
`Laravel\Tinker\ClassAliasAutoloader::__construct(): Failed opening required`