### PR TITLE
[1.0] Use PSR-1 in PHPunit TestCase

### DIFF
--- a/tests/TinkerCasterTest.php
+++ b/tests/TinkerCasterTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Laravel\Tinker\TinkerCaster;
 use Illuminate\Support\Collection;
 
-class TinkerCasterTest extends PHPUnit_Framework_TestCase
+class TinkerCasterTest extends TestCase
 {
     public function testCanCastCollection()
     {


### PR DESCRIPTION
Use PSR-1 while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that no longer support snake case namespaces.