### PR TITLE
allow adding custom casters and overriding laravel's own via config

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -34,6 +34,13 @@ class TinkerCommand extends Command
     protected $description = 'Interact with your application';
 
     /**
+     * Custom, user-defined casters for even better experience.
+     *
+     * @var array
+     */
+    protected $casters = [];
+
+    /**
      * Execute the console command.
      *
      * @return void
@@ -102,7 +109,20 @@ class TinkerCommand extends Command
             $casters['Illuminate\Foundation\Application'] = 'Laravel\Tinker\TinkerCaster::castApplication';
         }
 
-        return $casters;
+        return array_merge($casters, $this->casters);
+    }
+
+    /**
+     * Set cusomized casters for this tinker session.
+     *
+     * @param  array $casters
+     * @return $this
+     */
+    public function setCasters(array $casters)
+    {
+        $this->casters = $casters;
+
+        return $this;
     }
 
     /**

--- a/src/TinkerServiceProvider.php
+++ b/src/TinkerServiceProvider.php
@@ -21,8 +21,10 @@ class TinkerServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('command.tinker', function () {
-            return new TinkerCommand;
+        $this->app->singleton('command.tinker', function ($app) {
+            return (new TinkerCommand)->setCasters(
+                $app['config']->get('tinker.casters', [])
+            );
         });
 
         $this->commands(['command.tinker']);


### PR DESCRIPTION
Hi!

This one allows adding custom and/or overriding laravel's own PsySH casters via array provided in  `config('tinker.casters')`

```php
=> Carbon\Carbon @1519569240 {#745
     +date: "2018-02-25 14:34:00.000000",
     +weekday: "Sunday",
     +day_of_year: 55,
     +unix: 1519569240,
     +diff_for_humans: "6 days ago",
   }
```

<details><summary>
Setup
</summary>

```php
// config/tinker.php
return [
    'casters' => [
        // ordinary class-based method:
        Carbon\Carbon::class => 'App\Console\Casters::carbon',

        // or inline:
        Carbon\Carbon::class => function (Carbon\Carbon $carbon) {
            return [
                'date' => $carbon->date,
                'weekday' => $carbon->format('l'),
                'day_of_year' => (int) $carbon->format('z'),
                'unix' => (int) $carbon->format('U'),
                'diff_for_humans' => $carbon->diffForHumans(),
            ];
        },
    ],
];
```

```php
namespace App\Console;

class Casters
{
    public static function carbon(Carbon\Carbon $carbon)
    {
        return [
            'date' => $carbon->date,
            'weekday' => $carbon->format('l'),
            'day_of_year' => (int) $carbon->format('z'),
            'unix' => (int) $carbon->format('U'),
            'diff_for_humans' => $carbon->diffForHumans(),
        ];
    }
}
```
</details>