### PR TITLE
Introduce exclude_aliases option to allow classes to be excluded from class aliasing.

### DIFF
--- a/config/tinker.php.stub
+++ b/config/tinker.php.stub
@@ -1,0 +1,16 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Prefixes to be excluded when generating class aliases for tinker.
+    | You can provide fully-qualified class names to exclude specific classes,
+    | or namespaces to exclude multiple classes within that namespace.
+    |--------------------------------------------------------------------------
+    */
+
+    'exclude_aliases' => [
+    ],
+
+];

--- a/src/ClassAliasAutoloader.php
+++ b/src/ClassAliasAutoloader.php
@@ -50,8 +50,17 @@ class ClassAliasAutoloader
 
         $classes = require $classMapPath;
 
+        $excludedAliases = collect(config('tinker.exclude_aliases'));
+
         foreach ($classes as $class => $path) {
             if (! Str::contains($class, '\\') || Str::startsWith($path, $vendorPath)) {
+                continue;
+            }
+
+            if (! $excludedAliases->filter(
+                function ($alias) use ($class) {
+                    return Str::startsWith($class, $alias);
+                })->isEmpty()) {
                 continue;
             }
 

--- a/src/TinkerServiceProvider.php
+++ b/src/TinkerServiceProvider.php
@@ -25,6 +25,10 @@ class TinkerServiceProvider extends ServiceProvider
             return new TinkerCommand;
         });
 
+        $this->publishes([
+            __DIR__ . '/../config/tinker.php.stub' => config_path('tinker.php'),
+        ], 'config');
+
         $this->commands(['command.tinker']);
     }
 


### PR DESCRIPTION
Currently tinker class aliasing takes the first matching class alias based on alphabetical ordering. This works well in a lot of cases. However, there are cases when this logic isn't sufficient to allow selecting the correct alias, and can easily result in unhelpful aliases being generated. 

This PR introduces an (optional) config file that can be published with an artisan command:
 
```
php artisan vendor:publish --provider=Laravel\\Tinker\\TinkerServiceProvider --tag="config"
```

This config file contains an array option called `exclude_aliases` which can be populated with either fully-qualified class names to block specific classes being used for alias resolution, or namespace prefixes.

For example, in my current project I have the following structure:

- App
    - Formatters
         - Song
- App
    - Models
         - Song

Without this change, a tinker request for `Song` will resolve `App\Formatters\Song` as it comes first alphabetically - which 99.99%  of the time isn't the class I want. With this PR, I can set the config as follows:

```
'exclude_aliases' => [
    'App\Formatters',
],
```

With this in place, tinker will ignore all of the classes in the App\Formatters namespace and resolve the correct class alias for me. 

*Note:* There doesn't seem to be any documentation of the class aliasing feature in this repo currently, so I haven't updated the README to talk about this, but happy to do so if you believe it would be helpful.