### PR TITLE
Allow psysh 0.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/console": "~5.1",
         "illuminate/contracts": "~5.1",
         "illuminate/support": "~5.1",
-        "psy/psysh": "0.7.*|0.8.*",
+        "psy/psysh": "0.7.*|0.8.*|0.9.*",
         "symfony/var-dumper": "~3.0|~4.0"
     },
     "require-dev": {


### PR DESCRIPTION
Allows psysh 0.9.

---

You may ask, why now allow all 0.x series - well, we don't know if things will break. This is definitely safest, and not much effort to test each new minor 0.x release. Once we reach 1.x, we can safely allow any 1.x, as per semver.