### PR TITLE
Ability to add custom commands

### DIFF
--- a/config/tinker.php
+++ b/config/tinker.php
@@ -4,6 +4,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Custom commands
+    |--------------------------------------------------------------------------
+    |
+    | Sometimes, you might want to make certain console commands available in
+    | Tinker. This option allows you to do just that. Simply provide a list
+    | of commands that you want to expose in Tinker.
+    |
+    */
+
+    'commands' => [],
+
+    /*
+    |--------------------------------------------------------------------------
     | Alias Blacklist
     |--------------------------------------------------------------------------
     |

--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -80,6 +80,10 @@ class TinkerCommand extends Command
             }
         }
 
+        foreach (config('tinker.commands', []) as $command) {
+            $commands[] = $this->getApplication()->resolve($command);
+        }
+
         return $commands;
     }
 


### PR DESCRIPTION
This PR introduces an ability to register custom commands in Tinker. This allows users to create a standard Laravel console command and call it from Tinker.

Examples of use:
* query logger/debugger:
    ```
    >>> debug_queries
    >>> Order::first()->getReport()
    Report #67: ...
    >>> show_queries
    There are 42 queries captured.

    1. select * from order_categories;
    2. select id from order_type where tag = 'internal';
    ...
    ```
* testing out auth-dependent commands:
    ```
    >>> log_in
    >>> auth()->user()->getProfilePicture()
    ```

And bunch of other cool things! Thanks