### PR TITLE
Add support for laravel/framework < v5.4.17

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -54,7 +54,7 @@ class TinkerCommand extends Command
         $shell->addCommands($this->getCommands());
         $shell->setIncludes($this->argument('include'));
 
-        $path = $this->getLaravel()->basePath('vendor/composer/autoload_classmap.php');
+        $path = base_path('vendor/composer/autoload_classmap.php');
 
         $loader = ClassAliasAutoloader::register($shell, $path);
 


### PR DESCRIPTION
After [the update to ServiceProviders](https://github.com/laravel/framework/commit/78b3fe6bdc6d8219c4b6aca5a160e27c9e65b3d8), the `basePath()` function in `Illuminate\Foundation\Application` was extended to support an additional parameter `$path`. This was not documented nor updated in [the contract](https://github.com/laravel/framework/blob/5.6/src/Illuminate/Contracts/Foundation/Application.php#L21). When attempting to use `laravel/tinker` on a `laravel/framework` installation prior to v5.4.17, the following exception is thrown:

```
[Symfony\Component\Debug\Exception\FatalErrorException]
Laravel\Tinker\ClassAliasAutoloader::__construct(): Failed opening required '/data/projects/project' (include_path='.:/usr/share/php')
```

This commit relies on the `base_path` function which supports the `$path` argument and is available on all versions (and is not deprecated as [of 5.6](https://github.com/laravel/framework/blob/5.6/src/Illuminate/Foundation/helpers.php#L183).