### PR TITLE
Add support for laravel/framework < v5.4.17

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -54,7 +54,7 @@ class TinkerCommand extends Command
         $shell->addCommands($this->getCommands());
         $shell->setIncludes($this->argument('include'));
 
-        $path = $this->getLaravel()->basePath('vendor/composer/autoload_classmap.php');
+        $path = $this->getLaravel()->basePath().DIRECTORY_SEPARATOR.'vendor/composer/autoload_classmap.php';
 
         $loader = ClassAliasAutoloader::register($shell, $path);
 


### PR DESCRIPTION
This is my second attempt to address the issue (initially #48 was merged which broke Lumen installs unfortunately).

Requesting review by @GrahamCampbell 

> After [the update to ServiceProviders](laravel/framework@78b3fe6), the `basePath()` function in `Illuminate\Foundation\Application` was extended to support an additional parameter `$path`. This was not documented nor updated in [the contract](laravel/framework:src/Illuminate/Contracts/Foundation/Application.php@5.6#L21). When attempting to use `laravel/tinker` on a `laravel/framework` installation prior to v5.4.17, the following exception is thrown:
> 
> ```
> [Symfony\Component\Debug\Exception\FatalErrorException]
> 
> Laravel\Tinker\ClassAliasAutoloader::__construct():
> Failed opening required '/data/projects/project'
> (include_path='.:/usr/share/php')
> ```
> 
> This commit reverts to the old `basePath()` behaviour without passing an argument and does the path construction within the `TinkerCommand` instead.
> 
> We cannot rely on the `base_path()` helper as it's not available in Lumen.
