### PR TITLE
Configurable Psy Options via Tinker Configs

### DIFF
--- a/config/tinker.php
+++ b/config/tinker.php
@@ -2,6 +2,9 @@
 
 return [
 
+
+    ### Tinker Options ### 
+
     /*
     |--------------------------------------------------------------------------
     | Alias Blacklist
@@ -14,5 +17,32 @@ return [
     */
 
     'dont_alias' => [],
+
+
+    ### Optional ###  - Psy Shell Custom Options 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Psy Custom Options Path
+    |--------------------------------------------------------------------------
+    |
+    | Specify a path for mounting custom Psy shell configuration options
+    | Uncomment this line to enable Psy custom options.
+    |
+    */
+
+    // 'options_path' => getenv('PSYSH_CONFIG'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Psy Custom Prompt.
+    |--------------------------------------------------------------------------
+    |
+    | You can customize your Tinker Shell's prompt. Uncomment this line to 
+    | define a custom prompt.
+    |
+    */
+
+    // 'prompt' => config('app.name - Tinker') . '>>>',
 
 ];

--- a/config/tinker.php
+++ b/config/tinker.php
@@ -31,7 +31,7 @@ return [
     |
     */
 
-    // 'options_path' => getenv('PSYSH_CONFIG'),
+    // 'options_path' => __FILE__,
 
     /*
     |--------------------------------------------------------------------------
@@ -43,6 +43,6 @@ return [
     |
     */
 
-    // 'prompt' => config('app.name - Tinker') . '>>>',
+    // 'prompt' => '► ',
 
 ];

--- a/src/TinkerServiceProvider.php
+++ b/src/TinkerServiceProvider.php
@@ -23,6 +23,15 @@ class TinkerServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+
+        // If not already set, will inspect the application configuration options
+        // to check if a custom options_path has been set, if so, will signal
+        // Psy shell to mount custom options when it starts, PSYSH_CONFIG env var.
+        if(false === getenv('PSYSH_CONFIG'))
+            if(config('tinker.options_path'))
+                putenv('PSYSH_CONFIG=' . config('tinker.options_path'));
+
+
         $source = realpath($raw = __DIR__ . '/../config/tinker.php') ?: $raw;
 
         if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {

--- a/src/TinkerServiceProvider.php
+++ b/src/TinkerServiceProvider.php
@@ -23,16 +23,16 @@ class TinkerServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-
-        // If not already set, will inspect the application configuration options
-        // to check if a custom options_path has been set, if so, will signal
-        // Psy shell to mount custom options when it starts, PSYSH_CONFIG env var.
+        // Paths when already published and set in app's configs
         if(false === getenv('PSYSH_CONFIG'))
             if(config('tinker.options_path'))
-                putenv('PSYSH_CONFIG=' . config('tinker.options_path'));
+                putenv('PSYSH_CONFIG=' . $source = config('tinker.options_path'));
 
+        // Initial state, when not yet published, as not all apps will have published Tinker configs.
+        $source = isset($source) ? $source : ( 
+            realpath( $raw = __DIR__ . '/../config/tinker.php') ?: $raw 
+        );
 
-        $source = realpath($raw = __DIR__ . '/../config/tinker.php') ?: $raw;
 
         if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
             $this->publishes([$source => config_path('tinker.php')]);


### PR DESCRIPTION
Looks like there is no support for custom Psy shell options via Tinker's configuration options. I looked in the documentation and could find no mention of it. 

-- There is a way to bypass Laravel's configuration sys completely by setting a PSYSH_CONFIG env variable, but even then, you would end up with at least one additional file for those configurations somewhere.

So I've patched Tinker, to handle such a use case.

To see it in action, you would need to: 

`php artisan vendor:publish --publisher=laravel\tinker --tag=config`. 

Then uncomment the lines in the config/tinker.php file. 

Then run `php artisan config:clear`, to ensure its picked up.

Now when you run `php artisan tinker` you should see a new custom prompt.

It should work with all other Psy configuration options too. - :)