### PR TITLE
Explain issues of dispatching jobs from tinker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ To get started with Laravel Tinker, simply run:
 
 From your console, execute the `php artisan tinker` command.
 
+### Dispatching jobs
+
+The `dispatch` helper function as well as the `dispatch` method on your `Dispatchable` class depend on garbage collection to place the job on the queue. Therefore, when using Artisan `tinker`, you should use `Bus::dispatch` or `Queue::push` instead.
+
 ## License
 
 Laravel Tinker is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
Resubmitting from laravel/docs PR.

I wasted half a day wondering why dispatching jobs wasn't working as expected. Turned out it was a combination of using tinker and the fact that dispatch method uses garbage collection to put jobs on the queue.

I filed this bug, which was closed, because two other where already filed concerning the same problem. Many people are wasting their time when faced with this problem, so it would make sense to document that "known subtlety" (citing Graham here).

Thanks.