### PR TITLE
Don't alias App\Nova by default

### DIFF
--- a/config/tinker.php
+++ b/config/tinker.php
@@ -28,6 +28,8 @@ return [
     |
     */
 
-    'dont_alias' => [],
+    'dont_alias' => [
+        'App\Nova',
+    ],
 
 ];


### PR DESCRIPTION
This isn't a bug, but something minor that I believe could be improved. Generally my use of the autoloader in Tinker is to perform database queries, as it saves you prefixing each model with `App\`. However, if you're also using Nova in your app all those classes will take precedence because of the order they are loaded.

```sh
>>> User::first()
[!] Aliasing 'User' to 'App\Nova\User' for this Tinker session.
PHP Fatal error:  Call to undefined method User::first() in Psy Shell code on line 1
>>> App\User::first()
```

The easiest fix here would be not to alias Nova classes - and I wonder if this might be considered for the default config rather than something you'd have to add yourself.

```php
'dont_alias' => [
    'App\Nova'
],
```

Obviously it assumes your main namespace will be `App` for this to work, and it won't negatively affect anyone who isn't using Nova. However, it might be a nice improvement to the experience.