### PR TITLE
* Casters: Load casters that are included with the files

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -94,16 +94,27 @@ class TinkerCommand extends Command
      */
     protected function getCasters()
     {
-        $casters = [
-            'Illuminate\Support\Collection' => 'Laravel\Tinker\TinkerCaster::castCollection',
-        ];
+        $casters = [];
+        if (class_exists('Illuminate\Support\CollectionCaster')) {
+            $casters['Illuminate\Support\Collection'] = 'Illuminate\Support\CollectionCaster::cast';
+        } else {
+            $casters['Illuminate\Support\Collection'] = 'Laravel\Tinker\TinkerCaster::castCollection';
+        }
 
         if (class_exists('Illuminate\Database\Eloquent\Model')) {
-            $casters['Illuminate\Database\Eloquent\Model'] = 'Laravel\Tinker\TinkerCaster::castModel';
+            if (class_exists('Illuminate\Database\Eloquent\ModelCaster')) {
+                $casters['Illuminate\Database\Eloquent\Model'] = 'Illuminate\Database\Eloquent\ModelCaster::cast';
+            } else {
+                $casters['Illuminate\Database\Eloquent\Model'] = 'Laravel\Tinker\TinkerCaster::castModel';
+            }
         }
 
         if (class_exists('Illuminate\Foundation\Application')) {
-            $casters['Illuminate\Foundation\Application'] = 'Laravel\Tinker\TinkerCaster::castApplication';
+            if (class_exists('Illuminate\Foundation\ApplicationCaster')) {
+                $casters['Illuminate\Foundation\Application'] = 'Illuminate\Foundation\ApplicationCaster::cast';
+            } else {
+                $casters['Illuminate\Foundation\Application'] = 'Laravel\Tinker\TinkerCaster::castApplication';
+            }
         }
 
         return $casters;

--- a/src/TinkerCaster.php
+++ b/src/TinkerCaster.php
@@ -5,6 +5,9 @@ namespace Laravel\Tinker;
 use Exception;
 use Symfony\Component\VarDumper\Caster\Caster;
 
+/**
+ * @brief This class is kept as a fallback. Casters should be updated in laravel/framework.
+ */
 class TinkerCaster
 {
     /**


### PR DESCRIPTION
See: https://github.com/laravel/framework/pull/29087

This PR gives precedence to the casters included in laravel/framework, but keeps the casters around as a fallback (for those using older laravel versions).