### PR TITLE
Use COMPOSER_VENDOR_DIR

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -54,7 +54,12 @@ class TinkerCommand extends Command
         $shell->addCommands($this->getCommands());
         $shell->setIncludes($this->argument('include'));
 
-        $path = $this->getLaravel()->basePath().DIRECTORY_SEPARATOR.'vendor/composer/autoload_classmap.php';
+        if (isset($_ENV['COMPOSER_VENDOR_DIR'])) {
+            $path = $_ENV['COMPOSER_VENDOR_DIR'];
+        } else {
+            $path = $this->getLaravel()->basePath().DIRECTORY_SEPARATOR.'vendor';
+        }
+        $path .= '/composer/autoload_classmap.php';
 
         $loader = ClassAliasAutoloader::register($shell, $path);
 


### PR DESCRIPTION
By setting this var you can make Composer install the dependencies into a directory other than vendor.
https://getcomposer.org/doc/03-cli.md#composer-vendor-dir

Resolve the issue https://github.com/laravel/tinker/issues/65
