### PR TITLE
[2.x] Move docs to Laravel documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,6 @@ Laravel Tinker is a powerful REPL for the Laravel framework.
 
 Documentation for Tinker can be found on the [Laravel website](https://laravel.com/docs/6.x/artisan#tinker).
 
-### Installation
-
-To get started with Laravel Tinker, simply run:
-
-    composer require laravel/tinker
-
-### Dispatching Jobs
-
-The `dispatch` helper function and `dispatch` method on the `Dispatchable` class depends on garbage collection to place the job on the queue. Therefore, when using `tinker`, you should use `Bus::dispatch` or `Queue::push` to dispatch jobs.
-
 ## Contributing
 
 Thank you for considering contributing to Tinker! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).


### PR DESCRIPTION
This PR accompanies https://github.com/laravel/docs/pull/5654 to move the documentation to the docs repo so we have a single place where we can maintain it.