### PR TITLE
[2.x] Add HtmlString caster

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -104,6 +104,7 @@ class TinkerCommand extends Command
     {
         $casters = [
             'Illuminate\Support\Collection' => 'Laravel\Tinker\TinkerCaster::castCollection',
+            'Illuminate\Support\HtmlString' => 'Laravel\Tinker\TinkerCaster::castHtmlString',
         ];
 
         if (class_exists('Illuminate\Database\Eloquent\Model')) {

--- a/src/TinkerCaster.php
+++ b/src/TinkerCaster.php
@@ -69,6 +69,19 @@ class TinkerCaster
     }
 
     /**
+     * Get an array representing the properties of an html string.
+     *
+     * @param  \Illuminate\Support\HtmlString  $htmlString
+     * @return array
+     */
+    public static function castHtmlString($htmlString)
+    {
+        return [
+            Caster::PREFIX_VIRTUAL.'html' => $htmlString->toHtml(),
+        ];
+    }
+
+    /**
      * Get an array representing the properties of a model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model


### PR DESCRIPTION
Before:

```
>>> Illuminate\Mail\Markdown::parse("### test\n");
=> Illuminate\Support\HtmlString {#3811}
```

After:

```
>>> Illuminate\Mail\Markdown::parse("### test\n");
=> Illuminate\Support\HtmlString {#4008
     html: "<h3>test</h3>\n",
   }
```
