### PR TITLE
[2.x] Add --execute option to console command

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -147,7 +147,7 @@ class TinkerCommand extends Command
     protected function getOptions()
     {
         return [
-            ['execute', null, InputOption::VALUE_OPTIONAL, 'Execute the given bit of code inside Tinker'],
+            ['execute', null, InputOption::VALUE_OPTIONAL, 'Execute the given code using Tinker'],
         ];
     }
 }

--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -7,6 +7,7 @@ use Laravel\Tinker\ClassAliasAutoloader;
 use Psy\Configuration;
 use Psy\Shell;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class TinkerCommand extends Command
 {
@@ -63,6 +64,14 @@ class TinkerCommand extends Command
         $path .= '/composer/autoload_classmap.php';
 
         $loader = ClassAliasAutoloader::register($shell, $path);
+
+        if ($code = $this->option('execute')) {
+            $shell->execute($code);
+
+            $loader->unregister();
+
+            return 0;
+        }
 
         try {
             $shell->run();
@@ -127,6 +136,18 @@ class TinkerCommand extends Command
     {
         return [
             ['include', InputArgument::IS_ARRAY, 'Include file(s) before starting tinker'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['execute', null, InputOption::VALUE_OPTIONAL, 'Execute the given bit of code inside Tinker'],
         ];
     }
 }


### PR DESCRIPTION
This PR adds `--execute` option to the `php artisan tinker` command.

The idea is that by running `php artisan tinker --execute="dump(config('database'))"`, you can use tinker non-interactively.

This allows the user to use _tinker_ somewhat programmatically. It is **extremely** helpful in environments where an interactive shell is not available. **Laravel Vapor** for example. Debugging Vapor deployments becomes much easier.