### PR TITLE
Allow Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/console": "^6.0|^7.0",
-        "illuminate/contracts": "^6.0|^7.0",
-        "illuminate/support": "^6.0|^7.0",
+        "illuminate/console": "^6.0|^7.0|^8.0",
+        "illuminate/contracts": "^6.0|^7.0|^8.0",
+        "illuminate/support": "^6.0|^7.0|^8.0",
         "psy/psysh": "^0.9",
         "symfony/var-dumper": "^4.0|^5.0"
     },
@@ -22,7 +22,7 @@
         "phpunit/phpunit": "^8.0|^9.0"
     },
     "suggest": {
-        "illuminate/database": "The Illuminate Database package (^6.0|^7.0)."
+        "illuminate/database": "The Illuminate Database package (^6.0|^7.0|^8.0)."
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
We'll need this for when `laravel/laravel`'s `develop` branch becomes L8.