### PR TITLE
[2.x] Forward input options to psysh

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
         "illuminate/console": "^6.0|^7.0|^8.0",
         "illuminate/contracts": "^6.0|^7.0|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0",
-        "psy/psysh": "^0.9|^0.10",
-        "symfony/var-dumper": "^4.0|^5.0"
+        "psy/psysh": "^0.10.3",
+        "symfony/var-dumper": "^4.3|^5.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.1",
-        "phpunit/phpunit": "^8.0|^9.0"
+        "phpunit/phpunit": "^8.4|^9.0"
     },
     "suggest": {
         "illuminate/database": "The Illuminate Database package (^6.0|^7.0|^8.0)."

--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Laravel\Tinker\ClassAliasAutoloader;
 use Psy\Configuration;
 use Psy\Shell;
+use Psy\VersionUpdater\Checker;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -43,9 +44,8 @@ class TinkerCommand extends Command
     {
         $this->getApplication()->setCatchExceptions(false);
 
-        $config = new Configuration([
-            'updateCheck' => 'never',
-        ]);
+        $config = Configuration::fromInput($this->input);
+        $config->setUpdateCheck(Checker::NEVER);
 
         $config->getPresenter()->addCasters(
             $this->getCasters()
@@ -55,11 +55,7 @@ class TinkerCommand extends Command
         $shell->addCommands($this->getCommands());
         $shell->setIncludes($this->argument('include'));
 
-        if (isset($_ENV['COMPOSER_VENDOR_DIR'])) {
-            $path = $_ENV['COMPOSER_VENDOR_DIR'];
-        } else {
-            $path = $this->getLaravel()->basePath().DIRECTORY_SEPARATOR.'vendor';
-        }
+        $path = Env::get('COMPOSER_VENDOR_DIR', $this->getLaravel()->basePath().DIRECTORY_SEPARATOR.'vendor');
 
         $path .= '/composer/autoload_classmap.php';
 

--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -3,6 +3,7 @@
 namespace Laravel\Tinker\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Env;
 use Laravel\Tinker\ClassAliasAutoloader;
 use Psy\Configuration;
 use Psy\Shell;


### PR DESCRIPTION
This PR forwards things like `--no-ansi` and `-vv` to psysh in the proper way, instead of ignoring them. Once this PR is merged, we can tag tinker v2.4.0.

// cc @bobthecow