### PR TITLE
Fixed execute not unregistering loader and exit code

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -67,20 +67,20 @@ class TinkerCommand extends Command
         );
 
         if ($code = $this->option('execute')) {
-            $shell->execute($code);
-
-            $loader->unregister();
+            try {
+                $shell->execute($code);
+            } finally {
+                $loader->unregister();
+            }
 
             return 0;
         }
 
         try {
-            $shell->run();
+            return $shell->run();
         } finally {
             $loader->unregister();
         }
-
-        return 0;
     }
 
     /**


### PR DESCRIPTION
1. Fixes incorrect implementation within https://github.com/laravel/tinker/pull/89. In particular this matters if the command is called by code or tests etc.
2. Fixes the shell exit code not getting forwarded.