### PR TITLE
[2.x] Added new 'tinker.after-loop'-event

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -52,7 +52,7 @@ class TinkerCommand extends Command
             $this->getCasters()
         );
 
-        $shell = new TinkerShell($config);
+        $shell = new TinkerShell($this->getLaravel()->make('events'), $config);
         $shell->addCommands($this->getCommands());
         $shell->setIncludes($this->argument('include'));
 

--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -5,6 +5,7 @@ namespace Laravel\Tinker\Console;
 use Illuminate\Console\Command;
 use Illuminate\Support\Env;
 use Laravel\Tinker\ClassAliasAutoloader;
+use Laravel\Tinker\Shell\Listener\TinkerEventEmitter;
 use Laravel\Tinker\Shell\TinkerShell;
 use Psy\Configuration;
 use Psy\VersionUpdater\Checker;
@@ -52,7 +53,9 @@ class TinkerCommand extends Command
             $this->getCasters()
         );
 
-        $shell = new TinkerShell($this->getLaravel()->make('events'), $config);
+        $eventEmitter = new TinkerEventEmitter($this->getLaravel()->make('events'));
+
+        $shell = new TinkerShell($eventEmitter, $config);
         $shell->addCommands($this->getCommands());
         $shell->setIncludes($this->argument('include'));
 

--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -5,8 +5,8 @@ namespace Laravel\Tinker\Console;
 use Illuminate\Console\Command;
 use Illuminate\Support\Env;
 use Laravel\Tinker\ClassAliasAutoloader;
+use Laravel\Tinker\Shell\TinkerShell;
 use Psy\Configuration;
-use Psy\Shell;
 use Psy\VersionUpdater\Checker;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -52,7 +52,7 @@ class TinkerCommand extends Command
             $this->getCasters()
         );
 
-        $shell = new Shell($config);
+        $shell = new TinkerShell($config);
         $shell->addCommands($this->getCommands());
         $shell->setIncludes($this->argument('include'));
 

--- a/src/Events/AfterLoop.php
+++ b/src/Events/AfterLoop.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Tinker\Events;
+
+/**
+ * Gets fired after each run of the Tinker REPL.
+ */
+class AfterLoop
+{
+}

--- a/src/Shell/Listener/TinkerEventEmitter.php
+++ b/src/Shell/Listener/TinkerEventEmitter.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laravel\Tinker\Shell\Listener;
+
+use Psy\ExecutionLoop\AbstractListener;
+use Psy\Shell;
+
+class TinkerEventEmitter extends AbstractListener
+{
+    public function afterLoop(Shell $shell)
+    {
+        event('tinker.after-loop');
+    }
+
+    public static function isSupported()
+    {
+        return true;
+    }
+}

--- a/src/Shell/Listener/TinkerEventEmitter.php
+++ b/src/Shell/Listener/TinkerEventEmitter.php
@@ -2,14 +2,26 @@
 
 namespace Laravel\Tinker\Shell\Listener;
 
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Tinker\Events\AfterLoop;
 use Psy\ExecutionLoop\AbstractListener;
 use Psy\Shell;
 
 class TinkerEventEmitter extends AbstractListener
 {
+    /**
+     * @var Dispatcher
+     */
+    protected $dispatcher;
+
+    public function __construct(Dispatcher $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
     public function afterLoop(Shell $shell)
     {
-        event('tinker.after-loop');
+        $this->dispatcher->dispatch(new AfterLoop());
     }
 
     public static function isSupported()

--- a/src/Shell/TinkerShell.php
+++ b/src/Shell/TinkerShell.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Tinker\Shell;
 
-use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Tinker\Shell\Listener\TinkerEventEmitter;
 use Psy\Configuration;
 use Psy\Shell;
@@ -10,16 +9,16 @@ use Psy\Shell;
 class TinkerShell extends Shell
 {
     /**
-     * @var Dispatcher
+     * @var TinkerEventEmitter
      */
-    protected $dispatcher;
+    protected $emitter;
 
-    public function __construct(Dispatcher $dispatcher, Configuration $config = null)
+    public function __construct(TinkerEventEmitter $emitter, Configuration $config = null)
     {
         // This needs to be set before the call to parent::__construct, as
         // getDefaultLoopListeners is called inside parent::__construct and we
-        // need $this->dispatcher there!
-        $this->dispatcher = $dispatcher;
+        // need $this->emitter there!
+        $this->emitter = $emitter;
 
         parent::__construct($config);
     }
@@ -27,7 +26,7 @@ class TinkerShell extends Shell
     protected function getDefaultLoopListeners()
     {
         return array_merge(parent::getDefaultLoopListeners(), [
-            new TinkerEventEmitter($this->dispatcher),
+            $this->emitter,
         ]);
     }
 }

--- a/src/Shell/TinkerShell.php
+++ b/src/Shell/TinkerShell.php
@@ -2,15 +2,32 @@
 
 namespace Laravel\Tinker\Shell;
 
+use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Tinker\Shell\Listener\TinkerEventEmitter;
+use Psy\Configuration;
 use Psy\Shell;
 
 class TinkerShell extends Shell
 {
+    /**
+     * @var Dispatcher
+     */
+    protected $dispatcher;
+
+    public function __construct(Dispatcher $dispatcher, Configuration $config = null)
+    {
+        // This needs to be set before the call to parent::__construct, as
+        // getDefaultLoopListeners is called inside parent::__construct and we
+        // need $this->dispatcher there!
+        $this->dispatcher = $dispatcher;
+
+        parent::__construct($config);
+    }
+
     protected function getDefaultLoopListeners()
     {
         return array_merge(parent::getDefaultLoopListeners(), [
-            new TinkerEventEmitter(),
+            new TinkerEventEmitter($this->dispatcher),
         ]);
     }
 }

--- a/src/Shell/TinkerShell.php
+++ b/src/Shell/TinkerShell.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Tinker\Shell;
+
+use Laravel\Tinker\Shell\Listener\TinkerEventEmitter;
+use Psy\Shell;
+
+class TinkerShell extends Shell
+{
+    protected function getDefaultLoopListeners()
+    {
+        return array_merge(parent::getDefaultLoopListeners(), [
+            new TinkerEventEmitter(),
+        ]);
+    }
+}


### PR DESCRIPTION
This PR adds a new `'tinker.after-loop'` event, that gets fired after each execution
of a command in the tinker shell while.

## Example

If this gets merged, you could add this snippet to the `boot` method of your
`AppServiceProvider`:

```php
\Illuminate\Support\Facades\Event::listen('tinker.after-loop', function () {
    echo 'You just executed something through tinker!' . PHP_EOL;
});
```

and the following output would be generated during a tinker session:

```
» php artisan tinker
Psy Shell v0.10.3 (PHP 7.3.11-0ubuntu0.19.10.3 — cli) by Justin Hileman
>>> echo 'Hi GitHub' . PHP_EOL
Hi GitHub
You just executed something through tinker!
>>> echo 'Another one!' . PHP_EOL
Another one!
You just executed something through tinker!
>>>
```

## Motivation

This enables third-parties to react to commands executed during tinker sessions.
The concrete example that motivated this PR was Laravels `telescope` package.
Executed queries, logs or model-events will *not* be recorded by telescope, as
the application will not shut down while inside the tinker-loop. As an
example that can be used for replication (executed in a fresh Laravel application with `telescope` installed):

```
» php artisan tinker
Psy Shell v0.9.12 (PHP 7.3.11-0ubuntu0.19.10.3 — cli) by Justin Hileman
>>> App\User::create(['email' => 'tinker@example.com', 'name' => 'I will not be recorded', 'password' => 'password']);
=> App\User {#3133
     email: "tinker@example.com",
     name: "I will not be recorded",
     updated_at: "2020-04-10 11:49:55",
     created_at: "2020-04-10 11:49:55",
     id: 99,
   }
```

After you close the shell and navigate to `/telescope/models`, there is no entry
recorded, as the [`ListensForStorageOpportunities`-trait only handles the
termination of the app and worker loops
](https://github.com/laravel/telescope/blob/3.x/src/ListensForStorageOpportunities.php#L26).
This [caused confusion in the past](https://github.com/laravel/telescope/issues/189)
and could be fixed through the event implemented in this PR.

## Implementation

`Psy\Shell` has an array of [`$loopListeners`](https://github.com/bobthecow/psysh/blob/master/src/Shell.php#L72) that listen for certain lifecycle events of the
shell.

These are implementations of the [`Psy\ExecutionLoop\Listener`-interface](https://github.com/bobthecow/psysh/blob/master/src/ExecutionLoop/Listener.php) and can not be modified, once an
instance of `Psy\Shell` was constructed. They are set initially to whatever [`getDefaultLoopListeners()`](https://github.com/bobthecow/psysh/blob/master/src/Shell.php#L245)
returns. For this reason, I created a new `Laravel\Tinker\Shell` extends `Psy\Shell`, overwrites the `getDefaultLoopListeners()`-method and adds another Listener. This `Laravel\Tinker\Shell\Listener\TinkerEventEmitter`-Listener then publishes the `'tinker.after-loop'` event in its `afterLoop`-method, that gets called by [`Psy\Shell::afterLoop`](https://github.com/bobthecow/psysh/blob/master/src/Shell.php#L600).

The only modification to the existing Code is, that the `TinkerCommand` now
needs to construct a `TinkerShell` instead of the standard `Psy\Shell`.

### Notes

- I am not sure how I should add tests for this, as I did not found any existing tests that handle comparable situations. If tests are reqiured, it would be nice if someone could guide me in the right direction.
- I used the `event`-helper inside the `TinkerEventEmitter::afterLoop`-method. If this is discouraged I will change it to use `$this->app['events']->dispatch` or something like that.

If this gets merged, I would happily open another PR for `telescope` that makes the `ListensForStorageOpportunities`-trait also handle the `'tinker.after-loop'`-event and thereby make it work more reliably with tinker.