### PR TITLE
Make shell available so people can listen for events

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -52,7 +52,8 @@ class TinkerCommand extends Command
             $this->getCasters()
         );
 
-        $shell = new Shell($config);
+        $shell = $this->getLaravel()->make(Shell::class, [$config]);
+
         $shell->addCommands($this->getCommands());
         $shell->setIncludes($this->argument('include'));
 

--- a/src/TinkerServiceProvider.php
+++ b/src/TinkerServiceProvider.php
@@ -6,10 +6,10 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Support\ServiceProvider;
-use Psy\Configuration;
-use Psy\Shell;
 use Laravel\Lumen\Application as LumenApplication;
 use Laravel\Tinker\Console\TinkerCommand;
+use Psy\Configuration;
+use Psy\Shell;
 
 class TinkerServiceProvider extends ServiceProvider implements DeferrableProvider
 {

--- a/src/TinkerServiceProvider.php
+++ b/src/TinkerServiceProvider.php
@@ -2,9 +2,12 @@
 
 namespace Laravel\Tinker;
 
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Support\ServiceProvider;
+use Psy\Configuration;
+use Psy\Shell;
 use Laravel\Lumen\Application as LumenApplication;
 use Laravel\Tinker\Console\TinkerCommand;
 
@@ -35,6 +38,10 @@ class TinkerServiceProvider extends ServiceProvider implements DeferrableProvide
      */
     public function register()
     {
+        $this->app->bind(Shell::class, function (Container $app, array $params) {
+            return new Shell($params[0] ?? new Configuration);
+        });
+
         $this->app->singleton('command.tinker', function () {
             return new TinkerCommand;
         });
@@ -49,6 +56,6 @@ class TinkerServiceProvider extends ServiceProvider implements DeferrableProvide
      */
     public function provides()
     {
-        return ['command.tinker'];
+        return [Shell::class, 'command.tinker'];
     }
 }


### PR DESCRIPTION
Closes #101. Depends on https://github.com/bobthecow/psysh/pull/630.

You can listen for events now by adding the following code to the boot method of your app service provider:

```php
    public function boot()
    {
        $this->callAfterResolving(Shell::class, function (Shell $shell) {
            $shell->addLoopListener(...);
        }
    }
```