### PR TITLE
[2.x] Fixes missing output while using execute option

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -68,6 +68,7 @@ class TinkerCommand extends Command
 
         if ($code = $this->option('execute')) {
             try {
+                $shell->setOutput($this->output);
                 $shell->execute($code);
             } finally {
                 $loader->unregister();


### PR DESCRIPTION
When using tinker with the `execute` option, the output instance is missing on the $shell instance. Causing tinker not being able to show exceptions to the user. You can quickly reproduce this bug in a fresh Laravel application like so:

```
php artisan tinker --execute="throw new Exception('Foo');"
``` 

Gives the following error: `Error: Call to a member function writeln() on null`.

After this chance, you will get the expected output: `Exception with message 'Foo'`.