### PR TITLE
Imprive PHPUnit fixtures

### DIFF
--- a/tests/ClassAliasAutoloaderTest.php
+++ b/tests/ClassAliasAutoloaderTest.php
@@ -9,12 +9,12 @@ use Psy\Shell;
 
 class ClassAliasAutoloaderTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->classmapPath = __DIR__.'/fixtures/vendor/composer/autoload_classmap.php';
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->loader->unregister();
     }


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit fixtures reference](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp(): void` and `protected function tearDown(): void` methods.