### PR TITLE
 Sync develop with code from 2.x branch (reserved all commits)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,16 @@
 * text=auto
 
+*.blade.php diff=html
+*.css diff=css
+*.html diff=html
+*.md diff=markdown
+*.php diff=php
+
 /.github export-ignore
 /tests export-ignore
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .styleci.yml export-ignore
-CHANGELOG.md
+CHANGELOG.md export-ignore
 phpunit.xml.dist export-ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4, 8.0]
         laravel: [^6.0, ^7.0, ^8.0]
         exclude:
           - php: 7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release Notes
 
-## [Unreleased](https://github.com/laravel/tinker/compare/v2.4.2...master)
+## [Unreleased](https://github.com/laravel/tinker/compare/v2.5.0...2.x)
+
+
+## [v2.5.0 (2020-10-29)](https://github.com/laravel/tinker/compare/v2.4.2...v2.5.0)
+
+### Added
+- PHP 8 Support ([#116](https://github.com/laravel/tinker/pull/116))
 
 
 ## [v2.4.2 (2020-08-11)](https://github.com/laravel/tinker/compare/v2.4.1...v2.4.2)

--- a/composer.json
+++ b/composer.json
@@ -10,19 +10,19 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "illuminate/console": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
-        "psy/psysh": "^0.10.3",
-        "symfony/var-dumper": "^4.3|^5.0"
+        "php": "^7.2.5|^8.0",
+        "illuminate/console": "^6.0|^7.0|^8.0",
+        "illuminate/contracts": "^6.0|^7.0|^8.0",
+        "illuminate/support": "^6.0|^7.0|^8.0",
+        "psy/psysh": "^0.10.4",
+        "symfony/var-dumper": "^4.3.4|^5.0"
     },
     "require-dev": {
-        "mockery/mockery": "^1.3.1",
-        "phpunit/phpunit": "^8.4|^9.0"
+        "mockery/mockery": "~1.3.3|^1.4.2",
+        "phpunit/phpunit": "^8.5.8|^9.3.3"
     },
     "suggest": {
-        "illuminate/database": "The Illuminate Database package (^6.0|^7.0|^8.0|^9.0)."
+        "illuminate/database": "The Illuminate Database package (^6.0|^7.0|^8.0)."
     },
     "autoload": {
         "psr-4": {
@@ -37,6 +37,9 @@
         }
     },
     "extra": {
+        "branch-alias": {
+            "dev-master": "2.x-dev"
+        },
         "laravel": {
             "providers": [
                 "Laravel\\Tinker\\TinkerServiceProvider"

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
         "php": "^7.2.5|^8.0",
-        "illuminate/console": "^6.0|^7.0|^8.0",
-        "illuminate/contracts": "^6.0|^7.0|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
+        "illuminate/console": "^6.0|^7.0|^8.0|^9.0",
+        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
         "psy/psysh": "^0.10.4",
         "symfony/var-dumper": "^4.3.4|^5.0"
     },
@@ -22,7 +22,7 @@
         "phpunit/phpunit": "^8.5.8|^9.3.3"
     },
     "suggest": {
-        "illuminate/database": "The Illuminate Database package (^6.0|^7.0|^8.0)."
+        "illuminate/database": "The Illuminate Database package (^6.0|^7.0|^8.0|^9.0)."
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,9 +14,4 @@
             <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
 </phpunit>


### PR DESCRIPTION
This allows Testbench to properly require `laravel/laravel` 9.x on PHP 8.
