### PR TITLE
Support `symfony/var-dump` v6 for Laravel 9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,16 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.2, 7.3, 7.4, 8.0]
-        laravel: [^6.0, ^7.0, ^8.0]
+        laravel: [^6.0, ^7.0, ^8.0, ^9.0]
         exclude:
           - php: 7.2
             laravel: ^8.0
+          - php: 7.2
+            laravel: ^9.0
+          - php: 7.3
+            laravel: ^9.0
+          - php: 7.4
+            laravel: ^9.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
         "psy/psysh": "^0.10.4",
-        "symfony/var-dumper": "^4.3.4|^5.0"
+        "symfony/var-dumper": "^4.3.4|^5.0|^6.0"
     },
     "require-dev": {
         "mockery/mockery": "~1.3.3|^1.4.2",


### PR DESCRIPTION
Used to prepare integration tests for Laravel 9