### PR TITLE
Add migrate:install to whitelisted commands

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -19,7 +19,7 @@ class TinkerCommand extends Command
      * @var array
      */
     protected $commandWhitelist = [
-        'clear-compiled', 'down', 'env', 'inspire', 'migrate', 'optimize', 'up',
+        'clear-compiled', 'down', 'env', 'inspire', 'migrate', 'migrate:install', 'optimize', 'up',
     ];
 
     /**


### PR DESCRIPTION
as migrate depends on migrate:install to prepare database

In response to #136 