### PR TITLE
Fix command resolving

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -102,7 +102,7 @@ class TinkerCommand extends Command
         $config = $this->getLaravel()->make('config');
 
         foreach ($config->get('tinker.commands', []) as $command) {
-            $commands[] = $this->getApplication()->resolve($command);
+            $commands[] = $this->getLaravel()->resolve($command);
         }
 
         return $commands;


### PR DESCRIPTION
This PR fixes an issue where a change in Laravel 9 broke command resolving. The culprit is https://github.com/laravel/framework/pull/34873 which adds support for lazy loading. The change causes a `null` value to be returned for commands which are suppose to be lazy loaded and therefor these commands were never resolved or added to the Tinker session. 

The fix I'm attempting is to use the Laravel container instance instead of the console application. What we want to achieve is to resolve all commands beforehand and add them to the Psysh shell session. Afaik Psysh has no way of handling lazy loaded commands. Therefor we need to resolve them all beforehand.

All commands started working again when I did this change. I do not know of any side effects from making this change.

Fixes https://github.com/laravel/tinker/issues/143