### PR TITLE
Add Laravel app instance to command

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -102,7 +102,9 @@ class TinkerCommand extends Command
         $config = $this->getLaravel()->make('config');
 
         foreach ($config->get('tinker.commands', []) as $command) {
-            $commands[] = $this->getLaravel()->make($command);
+            $commands[] = $this->getApplication()->add(
+                $this->getLaravel()->make($command)
+            );
         }
 
         return $commands;


### PR DESCRIPTION
In #144 we solved the issue that none of the existing artisan commands were working anymore in Tinker. An additional fix is needed to set the Laravel app instance on the resolved commands so custom commands can keep on 
working. We can achieve this with how the original `resolve` method worked before the lazy load changes by using the `add` method that'll set the Laravel instance.

Fixes https://github.com/laravel/tinker/issues/145