### PR TITLE
Add `--file` option

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -98,7 +98,7 @@ class TinkerCommand extends Command
         if ($file = $this->option('file')) {
             return str(file_get_contents($file))
                 ->squish()
-                ->replace('<?php', '')
+                ->ltrim('<?php')
                 ->finish(';');
         }
     }

--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -66,7 +66,7 @@ class TinkerCommand extends Command
             $shell, $path, $config->get('tinker.alias', []), $config->get('tinker.dont_alias', [])
         );
 
-        if ($code = $this->option('execute')) {
+        if ($code = $this->getCodeToRun()) {
             try {
                 $shell->setOutput($this->output);
                 $shell->execute($code);
@@ -81,6 +81,25 @@ class TinkerCommand extends Command
             return $shell->run();
         } finally {
             $loader->unregister();
+        }
+    }
+
+    /**
+     * Get the potential code to run passed through the command line.
+     *
+     * @return string|null
+     */
+    protected function getCodeToRun()
+    {
+        if ($code = $this->option('execute')) {
+            return $code;
+        }
+
+        if ($file = $this->option('file')) {
+            return str(file_get_contents($file))
+                ->squish()
+                ->replace('<?php', '')
+                ->finish(';');
         }
     }
 
@@ -157,6 +176,7 @@ class TinkerCommand extends Command
     {
         return [
             ['execute', null, InputOption::VALUE_OPTIONAL, 'Execute the given code using Tinker'],
+            ['file', null, InputOption::VALUE_OPTIONAL, 'Run the code in the given file'],
         ];
     }
 }


### PR DESCRIPTION
This pull request adds support for a `--file` option that takes the code from the given file and executes it, similar to `--execute`.

My use case for this was setting up [Code Runner](https://github.com/formulahendry/vscode-code-runner) and wanting to be able to run it in my Laravel application context, instead of just PHP. For this, the following configuration is required:

```json
"code-runner.executorMap": {
  "php": "php artisan tinker --file"
},
```

![CleanShot 2022-11-07 at 15 34 35](https://user-images.githubusercontent.com/16060559/200336194-da8af0d5-173c-4207-9f0c-43e7b86ccbec.png)
