### PR TITLE
Set raw output when using `--execute`

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -52,6 +52,10 @@ class TinkerCommand extends Command
             $this->getCasters()
         );
 
+        if ($this->option('execute')) {
+            $config->setRawOutput(true);
+        }
+
         $shell = new Shell($config);
         $shell->addCommands($this->getCommands());
         $shell->setIncludes($this->argument('include'));


### PR DESCRIPTION
Following up https://github.com/laravel/tinker/pull/154, while trying to work around the refusal of the PR by using `--execute`, I realized the formatting was outputted with the result.

![image](https://user-images.githubusercontent.com/16060559/200622200-3922a353-c976-4fc2-bf38-cba09f919d5b.png)

To fix this, PsySH has a `rawOutput` option that needs to be set to true. When using it, the output is correct:

![CleanShot 2022-11-08 at 17 33 51](https://user-images.githubusercontent.com/16060559/200622313-e4a15024-5d97-4382-a594-f6d8135f70b9.png)

