### PR TITLE
Cast ProcessResult objects

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -131,6 +131,10 @@ class TinkerCommand extends Command
             $casters['Illuminate\Database\Eloquent\Model'] = 'Laravel\Tinker\TinkerCaster::castModel';
         }
 
+        if (class_exists('Illuminate\Process\ProcessResult')) {
+            $casters['Illuminate\Process\ProcessResult'] = 'Laravel\Tinker\TinkerCaster::castProcessResult';
+        }
+
         if (class_exists('Illuminate\Foundation\Application')) {
             $casters['Illuminate\Foundation\Application'] = 'Laravel\Tinker\TinkerCaster::castApplication';
         }

--- a/src/TinkerCaster.php
+++ b/src/TinkerCaster.php
@@ -95,6 +95,22 @@ class TinkerCaster
     }
 
     /**
+     * Get an array representing the properties of a process result.
+     *
+     * @param  \Illuminate\Process\ProcessResult  $result
+     * @return array
+     */
+    public static function castProcessResult($result)
+    {
+        return [
+            Caster::PREFIX_VIRTUAL.'output' => $result->output(),
+            Caster::PREFIX_VIRTUAL.'errorOutput' => $result->errorOutput(),
+            Caster::PREFIX_VIRTUAL.'exitCode' => $result->exitCode(),
+            Caster::PREFIX_VIRTUAL.'successful' => $result->successful(),
+        ];
+    }
+
+    /**
      * Get an array representing the properties of a model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model


### PR DESCRIPTION
As I just made this change in Tinkerwell myself, I thought it would be nice to contribute this to tinker as well.

This PR adds the ability to cast the new `Illuminate\Process\ProcessResult` objects when running them inside of tinker.

Without this PR:

<img width="1416" alt="CleanShot 2023-02-15 at 17 33 06@2x" src="https://user-images.githubusercontent.com/804684/219092246-2d3e0a9d-a742-494e-b698-7c753be1ccf9.png">

With casting:

<img width="1416" alt="CleanShot 2023-02-15 at 17 32 31@2x" src="https://user-images.githubusercontent.com/804684/219092283-86d1dcfe-5bf7-46bd-996d-153cb3167552.png">
