### PR TITLE
Use psysh with Semicolon for more compatibility 

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -46,6 +46,7 @@ class TinkerCommand extends Command
         $this->getApplication()->setCatchExceptions(false);
 
         $config = Configuration::fromInput($this->input);
+        $config->setRequireSemicolons(true);
         $config->setUpdateCheck(Checker::NEVER);
 
         $config->getPresenter()->addCasters(


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I Tink that this MR will give more compatibility between Psysh and Laravel / Pint by allowing the brackets to be on a new line.

In itself, that is not a problem from Psysh as @bobthecow  explained in this post:

https://github.com/laravel/tinker/issues/161#issuecomment-1481037313


This MR has breaking changes that will make semicolons mandatory in Tinker, but it's something we're used to by now.

```php
User::all()

```
It will always have to be with a semicolon at the end

```php
User::all();
```

The list of Psysh  options is here:
https://github.com/bobthecow/psysh/wiki/Config-options#-config-options


## Test Data:

```php
$data = [
    "1111",
    "2222",
    "3333",
    "4444",
];
foreach ($data as $pos)
{
    echo $pos . "\n";
}
```

Result:
```
4444
```

Now with the curly backet in the same line of the foreach
```php
$data = [
    "1111",
    "2222",
    "3333",
    "4444",
];
foreach ($data as $pos){
    echo $pos . "\n";
}`
```

Result :
```
1111
2222
3333
4444
```



Thanks

