### PR TITLE
Return correct exit code on exceptions

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -73,7 +73,10 @@ class TinkerCommand extends Command
         if ($code = $this->option('execute')) {
             try {
                 $shell->setOutput($this->output);
-                $shell->execute($code);
+                $shell->execute($code, true);
+            } catch (\Throwable $e) {
+                $shell->writeException($e);
+                return 1;
             } finally {
                 $loader->unregister();
             }


### PR DESCRIPTION
This PR modifies the behaviour of the `--execute` option to have it return an exit code of 1 when an exception is thrown.

Currently all exceptions are caught and rendered by Psysh internally, which makes it difficult to determine whether the command succeeded.