### PR TITLE
[3.x] Return correct exit code on exceptions

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -69,7 +69,10 @@ class TinkerCommand extends Command
         if ($code = $this->option('execute')) {
             try {
                 $shell->setOutput($this->output);
-                $shell->execute($code);
+                $shell->execute($code, true);
+            } catch (\Throwable $e) {
+                $shell->writeException($e);
+                return 1;
             } finally {
                 $loader->unregister();
             }

--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -10,6 +10,7 @@ use Psy\Shell;
 use Psy\VersionUpdater\Checker;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
+use Throwable;
 
 class TinkerCommand extends Command
 {
@@ -70,8 +71,9 @@ class TinkerCommand extends Command
             try {
                 $shell->setOutput($this->output);
                 $shell->execute($code, true);
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $shell->writeException($e);
+
                 return 1;
             } finally {
                 $loader->unregister();


### PR DESCRIPTION
This PR modifies the behaviour of the `--execute` option to have it return an exit code of 1 when an exception is thrown.

Currently all exceptions are caught and rendered by Psysh internally, which makes it difficult to determine whether the command succeeded.

[Original PR](https://github.com/laravel/tinker/pull/163)
Reopened on master branch as per https://github.com/laravel/tinker/pull/163#issuecomment-1628516836