### PR TITLE
[2.x] Remove unused `orchestra/testbench` deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
     },
     "require-dev": {
         "mockery/mockery": "~1.3.3|^1.4.2",
-        "orchestra/testbench": "^4.0|^5.0|^6.0|^6.0|^7.0|^8.0",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^8.5.8|^9.3.3"
     },


### PR DESCRIPTION
This opens up the opportunity to require and run `tinker` directly from a package using `orchestra/testbench`.

```bash
php vendor/bin/testbench package:discover
php vendor/bin/testbench tinker
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
