### PR TITLE
Update PsySH dependency to v0.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/console": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "psy/psysh": "^0.10.4|^0.11.1",
+        "psy/psysh": "^0.10.4|^0.11.1|^0.12.0",
         "symfony/var-dumper": "^4.3.4|^5.0|^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
Tested locally against 2.x, confirmed support with upcoming PHP-Parser 5.x.

This shouldn't break backwards compatibility in any way, as the major change was dropping support for PHP versions so old that Laravel hasn't thought about them in years :) 