### PR TITLE
Master

### DIFF
--- a/src/ClassAliasAutoloader.php
+++ b/src/ClassAliasAutoloader.php
@@ -51,9 +51,9 @@ class ClassAliasAutoloader
      * @param  array  $excludedAliases
      * @return static
      */
-    public static function register(Shell $shell, $classMapPath, array $includedAliases = [], array $excludedAliases = [])
+    public static function register(Shell $shell, $classMapPath, array $includedAliases = [], array $excludedAliases = [], array $classAliases = [])
     {
-        return tap(new static($shell, $classMapPath, $includedAliases, $excludedAliases), function ($loader) {
+        return tap(new static($shell, $classMapPath, $includedAliases, $excludedAliases, $classAliases), function ($loader) {
             spl_autoload_register([$loader, 'aliasClass']);
         });
     }
@@ -67,7 +67,7 @@ class ClassAliasAutoloader
      * @param  array  $excludedAliases
      * @return void
      */
-    public function __construct(Shell $shell, $classMapPath, array $includedAliases = [], array $excludedAliases = [])
+    public function __construct(Shell $shell, $classMapPath, array $includedAliases = [], array $excludedAliases = [], array $classAliases = [])
     {
         $this->shell = $shell;
         $this->vendorPath = dirname(dirname($classMapPath));
@@ -86,6 +86,13 @@ class ClassAliasAutoloader
             if (! isset($this->classes[$name])) {
                 $this->classes[$name] = $class;
             }
+        }
+
+        foreach ($classAliases as $alias => $class) {
+            if (!isset($classes[$class])) {
+                continue;
+            }
+            $this->classes[$alias] = $class;
         }
     }
 

--- a/src/ClassAliasAutoloader.php
+++ b/src/ClassAliasAutoloader.php
@@ -89,7 +89,7 @@ class ClassAliasAutoloader
         }
 
         foreach ($classAliases as $alias => $class) {
-            if (!isset($classes[$class])) {
+            if (! isset($classes[$class])) {
                 continue;
             }
             $this->classes[$alias] = $class;

--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -72,7 +72,7 @@ class TinkerCommand extends Command
             $path,
             $config->get('tinker.alias', []),
             $config->get('tinker.dont_alias', []),
-            classAliases: $config->get('tinker.class_alias', [])
+            $config->get('tinker.class_alias', [])
         );
 
         if ($code = $this->option('execute')) {

--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -68,7 +68,11 @@ class TinkerCommand extends Command
         $config = $this->getLaravel()->make('config');
 
         $loader = ClassAliasAutoloader::register(
-            $shell, $path, $config->get('tinker.alias', []), $config->get('tinker.dont_alias', [])
+            $shell,
+            $path,
+            $config->get('tinker.alias', []),
+            $config->get('tinker.dont_alias', []),
+            classAliases: $config->get('tinker.class_alias', [])
         );
 
         if ($code = $this->option('execute')) {

--- a/tests/ClassAliasAutoloaderTest.php
+++ b/tests/ClassAliasAutoloaderTest.php
@@ -78,4 +78,20 @@ class ClassAliasAutoloaderTest extends TestCase
         $this->assertTrue(class_exists('Three'));
         $this->assertInstanceOf(\One\Two\Three::class, new \Three);
     }
+
+    public function testCanAliasClassesToAnotherName()
+    {
+        $this->loader = ClassAliasAutoloader::register(
+            $shell = Mockery::mock(Shell::class),
+            $this->classmapPath,
+            classAliases: ['Four' => 'One\Two\Three']
+        );
+
+        $shell->shouldReceive('writeStdout')
+            ->with("[!] Aliasing 'Four' to 'One\Two\Three' for this Tinker session.\n")
+            ->once();
+
+        $this->assertTrue(class_exists('Four'));
+        $this->assertInstanceOf(\One\Two\Three::class, new \Four);
+    }
 }

--- a/tests/ClassAliasAutoloaderTest.php
+++ b/tests/ClassAliasAutoloaderTest.php
@@ -84,7 +84,9 @@ class ClassAliasAutoloaderTest extends TestCase
         $this->loader = ClassAliasAutoloader::register(
             $shell = Mockery::mock(Shell::class),
             $this->classmapPath,
-            classAliases: ['Four' => 'One\Two\Three']
+            [],
+            [],
+            ['Four' => 'One\Two\Three']
         );
 
         $shell->shouldReceive('writeStdout')


### PR DESCRIPTION
This pull request adds support for class_alias to Tinker's configuration.

Motivation:
We created a model App\Models\Event, which conflicts with the `events` facade. As a result, instead of the Event model class being aliased, the `events` facade was aliased.

This solution allows users to map the conflicting class name to another class. For example, in config/tinker.php.
```php
<?php

return [
    'class_alias' => [
        'AppEvent' => App\Models\Event::class,
    ],
];
```