### PR TITLE
Fix: Correct vendor directory path resolution for Laravel Artisan Tin…

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Tinker\Console;
 
+use Composer\InstalledVersions;
 use Illuminate\Console\Command;
 use Illuminate\Support\Env;
 use Laravel\Tinker\ClassAliasAutoloader;
@@ -60,7 +61,12 @@ class TinkerCommand extends Command
         $shell->addCommands($this->getCommands());
         $shell->setIncludes($this->argument('include'));
 
-        $path = Env::get('COMPOSER_VENDOR_DIR', $this->getLaravel()->basePath().DIRECTORY_SEPARATOR.'vendor');
+        $vendorDir = $this->getLaravel()->basePath().DIRECTORY_SEPARATOR.'vendor';
+        if(!is_dir($vendorDir)){
+            $vendorDir = realpath(InstalledVersions::getRootPackage()['install_path']) . DIRECTORY_SEPARATOR.'vendor';
+        }
+
+        $path = Env::get('COMPOSER_VENDOR_DIR', $vendorDir);
 
         $path .= '/composer/autoload_classmap.php';
 


### PR DESCRIPTION
### Overview
This pull request addresses an issue with the Laravel Artisan Tinker command where the vendor directory path might not be correctly determined when developers customize the vendor directory. This fix ensures flexibility in determining the vendor directory path while resolving issues with running the Laravel Artisan Tinker command in various environments.

### Changes
- Updated the code to dynamically determine the default vendor directory path based on the Laravel base path.
- Added a check to ensure the determined vendor directory is valid.
- If the vendor directory is not valid, it falls back to using the path obtained from `InstalledVersions::getRootPackage()`.
- Updated the code to use `Env::get` to retrieve the `COMPOSER_VENDOR_DIR` environment variable, allowing developers to customize the vendor directory path.


### Detailed Changes
```php
use Composer\InstalledVersions;
```
```php
$vendorDir = $this->getLaravel()->basePath().DIRECTORY_SEPARATOR.'vendor';
if (!is_dir($vendorDir)) {
    $vendorDir = realpath(InstalledVersions::getRootPackage()['install_path']) . DIRECTORY_SEPARATOR . 'vendor';
}

$path = Env::get('COMPOSER_VENDOR_DIR', $vendorDir);
```

### Testing
Verified that the `php artisan tinker` command works correctly with and without the `COMPOSER_VENDOR_DIR` environment variable set.
Ensured that the fallback to `InstalledVersions::getRootPackage()` is correctly handled when the vendor directory does not exist.

### Impact
This fix ensures that developers have the flexibility to customize the vendor directory path while maintaining the stability of the Laravel Artisan Tinker command in various deployment environments.

**Please review the changes and provide feedback**. This revision emphasizes the importance of flexibility in determining the vendor directory path, accommodating developers who may customize this directory according to their needs.


<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
