### PR TITLE
[3.x] Remove supports for PHP 8.0 and 7.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,56 +16,24 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4, '8.0', 8.1, 8.2, 8.3]
-        laravel: [6, 7, 8, 9, 10, 11]
+        php: [8.1, 8.2, 8.3]
+        laravel: [10, 11, 12]
         include:
           - php: 8.4
             laravel: 11
+          - php: 8.4
+            laravel: 12
+          - php: 8.1
+            laravel: 8
+          - php: 8.1
+            laravel: 9
+          - php: 8.2
+            laravel: 9
         exclude:
-          - php: 7.2
-            laravel: 8
-          - php: 7.2
-            laravel: 9
-          - php: 7.2
-            laravel: 10
-          - php: 7.2
-            laravel: 11
-          - php: 7.3
-            laravel: 9
-          - php: 7.3
-            laravel: 10
-          - php: 7.3
-            laravel: 11
-          - php: 7.4
-            laravel: 9
-          - php: 7.4
-            laravel: 10
-          - php: 7.4
-            laravel: 11
-          - php: '8.0'
-            laravel: 10
-          - php: '8.0'
-            laravel: 11
-          - php: 8.1
-            laravel: 6
-          - php: 8.1
-            laravel: 7
           - php: 8.1
             laravel: 11
-          - php: 8.2
-            laravel: 6
-          - php: 8.2
-            laravel: 7
-          - php: 8.2
-            laravel: 8
-          - php: 8.3
-            laravel: 6
-          - php: 8.3
-            laravel: 7
-          - php: 8.3
-            laravel: 8
-          - php: 8.3
-            laravel: 9
+          - php: 8.1
+            laravel: 12
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,4 +55,4 @@ jobs:
           composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts=^${{ matrix.laravel }}"
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -10,20 +10,20 @@
         }
     ],
     "require": {
-        "php": "^7.2.5|^8.0",
-        "illuminate/console": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "psy/psysh": "^0.11.1|^0.12.0",
-        "symfony/var-dumper": "^4.3.4|^5.0|^6.0|^7.0"
+        "php": "^8.1",
+        "illuminate/console": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "psy/psysh": "^0.12.0",
+        "symfony/var-dumper": "^5.4|^6.0|^7.0"
     },
     "require-dev": {
         "mockery/mockery": "~1.3.3|^1.4.2",
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^8.5.8|^9.3.3"
+        "phpunit/phpunit": "^9.6.8|^10.5"
     },
     "suggest": {
-        "illuminate/database": "The Illuminate Database package (^6.0|^7.0|^8.0|^9.0|^10.0|^11.0)."
+        "illuminate/database": "The Illuminate Database package (^8.0|^9.0|^10.0|^11.0|^12.0)."
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,7 @@
 >
     <testsuites>
         <testsuite name="Laravel Tinker Test Suite">
-            <directory suffix=".php">./tests/</directory>
+            <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
Packagist stated indicate low usage from older PHP version so it should good to remove support for older version.

![image](https://github.com/user-attachments/assets/aef01ebb-bf43-4f4e-86e8-4e8fe79a68ae)


<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
