### PR TITLE
Add Dependabot cooldown of 5 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
     groups:
       github-actions:
         patterns:
@@ -12,6 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
     target-branch: "1.x"
     groups:
       github-actions:
@@ -21,6 +25,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
     target-branch: "2.x"
     groups:
       github-actions:


### PR DESCRIPTION
This adds a 5-day cooldown to the Dependabot configuration so dependency update pull requests are only opened once an update has been available for 5 days. Applied to every update entry in `.github/dependabot.yml`.