### PR TITLE
Bump minimum PsySH version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/console": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
-        "psy/psysh": "^0.12.0",
+        "psy/psysh": "^0.12.19",
         "symfony/var-dumper": "^5.4|^6.0|^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
Since 3.0.0, Tinker calls `Psy\Configuration::setTrustProject()`, but PsySH only added that method in 0.12.19. The `^0.12.0` constraint still allows older releases, so a project that already had an older one installed hits `Call to undefined method` the moment Tinker boots. Those same releases are the ones affected by CVE-2026-25129, which is what the trust project prompt was added for.

#213 does the same for 2.x.

Fixes #211
